### PR TITLE
releases.json: add bootloader_version

### DIFF
--- a/firmware/1/releases.json
+++ b/firmware/1/releases.json
@@ -2,6 +2,7 @@
 	{
 		"required": false,
 		"version": [1, 7, 1],
+		"bootloader_version": [1, 6, 0],
 		"min_bridge_version": [1, 1, 5],
 		"min_firmware_version": [1, 6, 2],
 		"min_bootloader_version": [1, 5, 0],
@@ -15,6 +16,7 @@
 	{
 		"required": false,
 		"version": [1, 6, 3],
+		"bootloader_version": [1, 5, 1],
 		"min_bridge_version": [1, 1, 5],
 		"min_firmware_version": [1, 0, 0],
 		"min_bootloader_version": [1, 0, 0],
@@ -26,6 +28,7 @@
 	{
 		"required": false,
 		"version": [1, 6, 2],
+		"bootloader_version": [1, 5, 0],
 		"min_bridge_version": [1, 1, 5],
 		"min_firmware_version": [1, 0, 0],
 		"min_bootloader_version": [1, 0, 0],
@@ -37,6 +40,7 @@
 	{
 		"required": true,
 		"version": [1, 6, 1],
+		"bootloader_version": [1, 4, 0],
 		"min_bridge_version": [1, 1, 5],
 		"min_firmware_version": [1, 0, 0],
 		"min_bootloader_version": [1, 0, 0],

--- a/firmware/2/releases.json
+++ b/firmware/2/releases.json
@@ -2,6 +2,7 @@
 	{
 		"required": false,
 		"version": [2, 0, 9],
+		"bootloader_version": [2, 0, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 5],
 		"min_bootloader_version": [2, 0, 0],
@@ -13,6 +14,7 @@
 	{
 		"required": false,
 		"version": [2, 0, 8],
+		"bootloader_version": [2, 0, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 5],
 		"min_bootloader_version": [2, 0, 0],
@@ -24,6 +26,7 @@
 	{
 		"required": false,
 		"version": [2, 0, 7],
+		"bootloader_version": [2, 0, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 5],
 		"min_bootloader_version": [2, 0, 0],
@@ -35,6 +38,7 @@
 	{
 		"required": false,
 		"version": [2, 0, 6],
+		"bootloader_version": [2, 0, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 5],
 		"min_bootloader_version": [2, 0, 0],
@@ -45,6 +49,7 @@
 	{
 		"required": true,
 		"version": [2, 0, 5],
+		"bootloader_version": [2, 0, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 5],
 		"min_bootloader_version": [2, 0, 0],


### PR DESCRIPTION
For T1 taken from here https://github.com/trezor/trezor-mcu/blob/master/firmware/bl_check.c 