### PR TITLE
feat(fw): add 1.10.1 and 2.4.0 release.json

### DIFF
--- a/firmware/1/releases.json
+++ b/firmware/1/releases.json
@@ -1,6 +1,20 @@
 [
 	{
 		"required": false,
+		"version": [1, 10, 1],
+		"bootloader_version": [1, 10, 0],
+		"min_bridge_version": [2, 0, 25],
+		"min_firmware_version": [1, 6, 2],
+		"min_bootloader_version": [1, 5, 0],
+		"url": "data/firmware/1/trezor-1.10.1.bin",
+		"url_bitcoinonly": "data/firmware/1/trezor-1.10.1-bitcoinonly.bin",
+		"fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",
+		"fingerprint_bitcoinonly": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",
+		"notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-june-2021-c70aba9f0e3f",
+		"changelog": "* Safety checks setting in T1."
+	},
+	{
+		"required": false,
 		"version": [1, 10, 0],
 		"bootloader_version": [1, 10, 0],
 		"min_bridge_version": [2, 0, 25],

--- a/firmware/2/releases.json
+++ b/firmware/2/releases.json
@@ -1,6 +1,19 @@
 [
 	{
 		"required": false,
+		"version": [2, 4, 0],
+		"min_bridge_version": [2, 0, 7],
+		"min_firmware_version": [2, 0, 8],
+		"min_bootloader_version": [2, 0, 0],
+		"url": "data/firmware/2/trezor-2.4.0.bin",
+		"url_bitcoinonly": "data/firmware/2/trezor-2.4.0-bitcoinonly.bin",
+		"fingerprint": "d90265ee6d7d499c7d938b5322f71f27042da8a6fdaed54c224d31b65e868def",
+		"fingerprint_bitcoinonly": "89c91287ab7a9cd3ec246b6822a0d04b7d40401abef706cccafbb7b98bd6a3d7",
+		"notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-june-2021-c70aba9f0e3f",
+		"changelog": "* Locking the device by holding finger on the homescreen.\n* Support PIN of unlimited length.\n* Allow decreasing the output value in RBF transactions.\n* Reduce memory fragmentation.\n* Update FIDO icons.\n* Improve wording when showing multisig XPUBs."
+	},
+	{
+		"required": false,
 		"version": [2, 3, 6],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 8],


### PR DESCRIPTION
fingerprints from trezorctrl:

![Screenshot from 2021-06-09 13-54-36](https://user-images.githubusercontent.com/3435913/121349901-52ce6700-c92a-11eb-936f-af7c813d29f9.png)
![Screenshot from 2021-06-09 13-54-56](https://user-images.githubusercontent.com/3435913/121349913-55c95780-c92a-11eb-9f5c-d3abf2b434bf.png)
