### PR TITLE
fix(ci): set git strategy to clone

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ deploy to data.trezor.io:
   stage: deploy
   needs: []
   before_script: []
+  variables:
+    GIT_STRATEGY: clone
   only:
     refs:
       - master


### PR DESCRIPTION
Should fix check_releases.py failing because we don't have lfs files