### PR TITLE
add dev and readme to files structure

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,5 @@
+# Data storage for developers
+
+Various files for testing and developing purposes such as emulators, blockbook binaries etc. 
+
+Files contained here are deployed directly to the S3 storage and are not added to the git repository. We use the respective CIs to upload there directly.


### PR DESCRIPTION
Add dev folder with readme to explain what it is. It is intended for deploying for example built emulators, blockbook binaries used across our process with the intention to have it accessible from outside and having trusted storage for all these files. I suggest having the structure as dev/suite dev/firmware and so on.