### PR TITLE
chore(firmware): Generalize firmware-check script for all devices, backfill revisionIds into releases

### DIFF
--- a/.github/workflows/check_releases.yml
+++ b/.github/workflows/check_releases.yml
@@ -30,8 +30,4 @@ jobs:
               - 'firmware/2/releases.json'
         if: steps.changes.outputs.releases-json == 'true'
       - name: Check releases.json revisions
-        run: |
-          ./scripts/check-firmware-revisions.sh t1b1 \
-          && ./scripts/check-firmware-revisions.sh 1 \
-          && ./scripts/check-firmware-revisions.sh t2t1 \
-          && ./scripts/check-firmware-revisions.sh 2
+        run: ./scripts/check-all-firmware-revisions.sh

--- a/firmware/t2b1/releases.json
+++ b/firmware/t2b1/releases.json
@@ -11,6 +11,7 @@
     "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.8.0-bitcoinonly.bin",
     "fingerprint": "cf3ce230a69a681199f74cf6ac8c6c431f8fa7e0d0183437f93c5cc029fbd155",
     "fingerprint_bitcoinonly": "ae088439d44fc8643b8de28e0d7a8720cd3dbb247619f2742604bbe884542558",
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
     "changelog": "* Removed CoSi functionality. \n* Increased Optiga read timeout to avoid spurious RSODs.",
     "changelog_bitcoinonly": "* Removed CoSi functionality. \n* Increased Optiga read timeout to avoid spurious RSODs."
   },
@@ -26,6 +27,7 @@
     "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.7.2-bitcoinonly.bin",
     "fingerprint": "d072560f34782faf5537aa08a48c4e24671d4c60e9c291a00bfbf12cbc425666",
     "fingerprint_bitcoinonly": "5b6e312430de9db6ad3a843e1ba311f8cff9c6a691c20c0e69b711451a729f40",
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
     "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares. \n* Added support for Cardano Conway certificates [Universal fw only].",
     "changelog_bitcoinonly": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares."
   },
@@ -41,6 +43,7 @@
     "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.7.0-bitcoinonly.bin",
     "fingerprint": "522eb5db073c0f039f7164360668e75a43399d0b4e40edfd06f77f4401cd98aa",
     "fingerprint_bitcoinonly": "bb91489a4790b3668e2f5d574a729a0f43009510550fecb5e04c0937d355b2cf",
+    "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
     "changelog": "* Add translations capability. \n* Add loader to homescreen when locking the device. \n* Allow for going back to previous word in recovery process. \n* Clear sign ETH staking transactions on Everstake pool. [Universal fw only] \n* Display descriptors for BTC Taproot public keys. \n* Multiple Solana instructions improved. [Universal fw only] \n* Add missing semicolon character to the passphrase entry.",
     "changelog_bitcoinonly": "* Add translations capability. \n* Add loader to homescreen when locking the device. \n* Allow for going back to previous word in recovery process. \n* Display descriptors for BTC Taproot public keys. \n* Add missing semicolon character to the passphrase entry."
   },
@@ -55,6 +58,7 @@
     "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.6.4-bitcoinonly.bin",
     "fingerprint": "5ac16cb5002aa607908be376378a7fd1a1bc18f7b05e7a047cb1365840cc93ef",
     "fingerprint_bitcoinonly": "013d595fc621c12324afd90721c6a37d055d853f6af54d5432e27e6a425656dd",
+    "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
     "changelog": "* Trezor Safe 3 now supports Solana, expanding the range of cryptocurrencies it can securely manage. [Universal fw only] \n* Ethereum fees are now uniformly presented in Gwei, enhancing clarity and consistency for users. [Universal fw only] \n* Issue with missing address confirmation screens is now fixed. [Universal fw only] \n* Resolved an issue related to the invalid encoding of signatures from the Optiga chip.",
     "changelog_bitcoinonly": "* Resolved an issue related to the invalid encoding of signatures from the Optiga chip."
   },
@@ -69,6 +73,7 @@
     "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.6.3-bitcoinonly.bin",
     "fingerprint": "1aea81cf4a823951540a041ae52d1950efade73531f7640c85805f8950f11a38",
     "fingerprint_bitcoinonly": "6aecc9d9fd137a661f38ce36713aa0889b77ec4d35d91c68e01bda225cda2850",
+    "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
     "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy.",
     "changelog_bitcoinonly": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."
   }

--- a/firmware/t3t1/releases.json
+++ b/firmware/t3t1/releases.json
@@ -27,6 +27,7 @@
     "url_bitcoinonly": "data/firmware/t3t1/trezor-t3t1-2.8.0-bitcoinonly.bin",
     "fingerprint": "bd199ce0934769aca5c3a91f71fd48e533d88c8cf087b76ac49db415fa08c286",
     "fingerprint_bitcoinonly": "3dc847cc396fe83f5a324242097a4cf97fc64acf90516efcfcf23b6d3103a992",
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
     "changelog": "* Added tutorial flow. \n* Added Animated device label on homescreen/lockscreen. \n* Added word counter during wallet creation. \n* Improved change homescreen flow. \n* Improved swipe behavior and animations. \n* Increased Optiga read timeout to avoid spurious RSODs. \n* Fixed swipe back from address QR code screen. \n* Fixed device authenticity check. \n* Removed CoSi functionality.",
     "changelog_bitcoinonly": "* Added tutorial flow. \n* Added Animated device label on homescreen/lockscreen. \n* Added word counter during wallet creation. \n* Improved change homescreen flow. \n* Improved swipe behavior and animations. \n* Increased Optiga read timeout to avoid spurious RSODs. \n* Fixed swipe back from address QR code screen. \n* Fixed device authenticity check. \n* Removed CoSi functionality."
   },
@@ -42,6 +43,7 @@
     "url_bitcoinonly": "data/firmware/t3t1/trezor-t3t1-2.7.2-bitcoinonly.bin",
     "fingerprint": "4daa5fd3c4c92ee0d76855997dde09a7ee25f4165b118c521ab10957c5fc92b0",
     "fingerprint_bitcoinonly": "246cca86b0a8cfcac6b7e6b3fcf55f543a8a9c9fd1f8ff88cd0de00640cb25eb",
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
     "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares. \n* Added support for Cardano Conway certificates [Universal fw only].",
     "changelog_bitcoinonly": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares."
   }

--- a/scripts/check-all-firmware-revisions.sh
+++ b/scripts/check-all-firmware-revisions.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This is basically copy-paste of 
+#     https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/scripts/check-all-firmware-revisions.sh
+#
+#     Small adjustments are made because here we check releases.json here in data/firmware, not those in trezor-suite/connect-common.
+#     Please keep them in sync if possible.
+#
+
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
+
+cd "$PARENT_PATH/../firmware" || exit
+
+EXCLUDED_DIR="translations"
+
+for dir in */ ; do
+    DEVICE=${dir%/}
+    if [[ $EXCLUDED_DIR == "$DEVICE" ]]; then continue; fi
+    if [ -d "$dir" ]; then
+        if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DEVICE" ; then
+            exit 1
+        fi;
+    fi
+done

--- a/scripts/check-firmware-revisions.sh
+++ b/scripts/check-firmware-revisions.sh
@@ -3,7 +3,8 @@
 # This is basically copy-paste of 
 #     https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/scripts/check-firmware-revisions.sh
 #
-#     with small adjustments for. Please keep them in sync if possible.
+#     Small adjustments are made because here we check releases.json here in data/firmware, not those in trezor-suite/connect-common.
+#     Please keep them in sync if possible.
 #
 
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
@@ -16,11 +17,20 @@ fi
 
 DEVICE=$1
 
-if [[ $DEVICE != "t1b1" && $DEVICE != "t2t1" && $DEVICE != "1" && $DEVICE != "2" ]]
-    then
-        echo "device must be either 't1b1' or 't2t1' or '1' or '2' (lowercase!)"
-        exit 1
+RELEASES_FOLDER="$PARENT_PATH"/../firmware
+
+EXCLUDED_DIR="translations"
+
+if [[ $EXCLUDED_DIR == "$DEVICE" ]]; then
+    echo "Invalid device $DEVICE, this is a reserved folder."
+    exit 1
 fi
+if ! test -d "$RELEASES_FOLDER/$DEVICE"; then
+    echo "Device $DEVICE not found in releases folder!"
+    exit 1
+fi
+
+echo "CHECKING RELEASES FOR $DEVICE"
 
 BRANCH="main"
 REPO_DIR_NAME=$PARENT_PATH"/../../trezor-firmware-for-revision-check"
@@ -39,7 +49,7 @@ git fetch origin
 git checkout "$BRANCH"
 git reset "origin/$BRANCH" --hard
 
-DATA=$(jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$PARENT_PATH"/../firmware/"$DEVICE"/releases.json)
+DATA=$(jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json)
 
 for ROW in $DATA;
 do 


### PR DESCRIPTION
## Description

Followup to #88

- Create a new `check-all-firmware-revisions.sh` script, which runs `check-firmware-revisions.sh` for each device.
  - _(understood as an existing folder in [firmware folder](https://github.com/trezor/data/tree/master/firmware) except the special folder `translations`)_
- Generalize `check-firmware-revisions.sh` to work on all devices
- Backfill revisionIds for T3T1 and T2B1 into their `releases.json` files 

:information_source: because there is no `shellcheck` in trezor/data CI, I ran it locally on the two affected scripts

## CR instructions 

:eyes: see that CI ran :heavy_check_mark: for this PR, and [it checked all devices](https://github.com/trezor/data/actions/runs/10320994291/job/28572825261?pr=92). 

OPTIONAL: You may also try locally
```
./scripts/check-all-firmware-revisions.sh
./scripts/check-firmware-revisions.sh t3t1
``` 

OPTIONAL: The following should give error (invalid device name):
```
./scripts/check-firmware-revisions.sh t1234
./scripts/check-firmware-revisions.sh translations
```

## Related Issue

Part 2/3 of https://github.com/trezor/trezor-suite-private/issues/109