### PR TITLE
Fix/t3b1 json

### DIFF
--- a/firmware/t3b1/releases.json
+++ b/firmware/t3b1/releases.json
@@ -10,9 +10,9 @@
     "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
     "url": "data/firmware/t3b1/trezor-t3b1-2.8.3.bin",
     "fingerprint": "b659bdc5ddce208d46ce649fc7a8995ae49541c7c41a88ddaac5dfc038ffb5de",
-    "changelog": "* Renamed MATIC to POL, following a network upgrade.\n* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation\xa0*south*.",
+    "changelog": "* Renamed MATIC to POL, following a network upgrade.\n* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation south.",
     "url_bitcoinonly": "data/firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin",
     "fingerprint_bitcoinonly": "070a61b2a8653e4f9857810b6610d0a15f76ba627c7b6e5654a6de9a1c529049",
-    "changelog_bitcoinonly": "* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation\xa0*south*."
+    "changelog_bitcoinonly": "* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation south."
   }
 ]


### PR DESCRIPTION
1. Make sure `check_releases.py` is applied to all device models without having to list them explicitly. We forgot to add T3T1 and T3B1 which lead to an uncaught error in JSON formatting (see 2).
2. Fix the formatting error. JSON could not be parsed correctly which lead to a bug in Suite, see https://github.com/trezor/trezor-suite/pull/14626.

The error is caught when only the first commit is applied:
![Screenshot 2024-09-30 at 16 34 52](https://github.com/user-attachments/assets/49439b03-2672-4466-8983-4b1a9603fe8e)
