### PR TITLE
chore(firmware): decrease min bootloader version for t3b1 2.8.3

### DIFF
--- a/firmware/t3b1/releases.json
+++ b/firmware/t3b1/releases.json
@@ -3,7 +3,7 @@
     "required": false,
     "version": [2, 8, 3],
     "min_bridge_version": [2, 0, 7],
-    "min_bootloader_version": [2, 1, 8],
+    "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],
     "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",


### PR DESCRIPTION
Decreasing the requirement for 2.8.3 t3b1 FW so even devices with 2.1.7 BL can proceed in onboarding.

Suite PR [here](https://github.com/trezor/trezor-suite/pull/16029)