### PR TITLE
fix(fw): revert T3B1 min_bootloader_version bump

### DIFF
--- a/firmware/t3b1/releases.json
+++ b/firmware/t3b1/releases.json
@@ -3,7 +3,7 @@
     "required": false,
     "version": [2, 8, 9],
     "min_bridge_version": [2, 0, 7],
-    "min_bootloader_version": [2, 1, 8],
+    "min_bootloader_version": [2, 1, 7],
     "min_firmware_version": [2, 8, 3],
     "bootloader_version": [2, 1, 8],
     "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",


### PR DESCRIPTION
In #128 T3B1 `min_bootloader_version` was bumped even though there's no reason to (or it was communicated offline in which case please close this).