### PR TITLE
fix(firmware): minimum T3B1 bootloader version in script

### DIFF
--- a/scripts/releases-json.py
+++ b/scripts/releases-json.py
@@ -66,7 +66,7 @@ RELEASES = "releases.json"
 
 BOOTLOADER_MIN = {
     "T3T1": (2, 1, 6),
-    "T3B1": (2, 1, 8),
+    "T3B1": (2, 1, 7),
     "T2T1": (2, 0, 0),
     "T2B1": (2, 1, 1),
 }


### PR DESCRIPTION
I added the wrong version in first T3B1 release and it's been there since: e938790599502d45b8d39c8507aa5821e68e0ca6