### PR TITLE
chore(nix): add missing shellcheck

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,5 +14,6 @@ stdenv.mkDerivation {
     git-lfs
     git
     python39
+    shellcheck
   ];
 }


### PR DESCRIPTION
The dependency "shellcheck" is used in script `scripts/shellcheck.sh` but it was not included in `shell.nix`.