### PR TITLE
Fix/some relesases did not have translations of all languages

### DIFF
--- a/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 6, 1],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.6.3.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.6.3.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.6.3.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.6.3.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.6.3.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.6.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2b1/trezor-t2b1-2.6.3-bitcoinonly.bin",
   "fingerprint": "6aecc9d9fd137a661f38ce36713aa0889b77ec4d35d91c68e01bda225cda2850",
   "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."

--- a/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 6, 1],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.6.4.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.6.4.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.6.4.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.6.4.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.6.4.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.6.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2b1/trezor-t2b1-2.6.4-bitcoinonly.bin",
   "fingerprint": "013d595fc621c12324afd90721c6a37d055d853f6af54d5432e27e6a425656dd",
   "changelog": "* Resolved an issue related to the invalid encoding of signatures from the Optiga chip."

--- a/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.7.0.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.7.0.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.7.0.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.7.0.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.7.0.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.7.0.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.0.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.0.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.0.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.0.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.7.0-bitcoinonly.bin",
   "fingerprint": "bb91489a4790b3668e2f5d574a729a0f43009510550fecb5e04c0937d355b2cf",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.7.2.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.7.2.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.7.2.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.2.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.2.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.2.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.7.2-bitcoinonly.bin",
   "fingerprint": "5b6e312430de9db6ad3a843e1ba311f8cff9c6a691c20c0e69b711451a729f40",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.0.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.0.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.0.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.0.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.0.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.0.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.0.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.0.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.0.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.0.bin",
+    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.0.bin",
+    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.0.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.8.0-bitcoinonly.bin",
   "fingerprint": "ae088439d44fc8643b8de28e0d7a8720cd3dbb247619f2742604bbe884542558",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.10.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.10.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.10.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.10.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.10.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.10.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.10.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.10.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.10.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.10.bin",
+    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.10.bin",
+    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.10.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin",
   "fingerprint": "5bd50bbcf6435f97b6dc46f96ad11235965cd8a78619c573c3c0aca6822e9ed2",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.7.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.7.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.7.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.7.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.7.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.7.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.7.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.7.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.7.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.7.bin",
+    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.7.bin",
+    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.7.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.8.7-bitcoinonly.bin",
   "fingerprint": "6381f8a373f9f91a3cf4000a762b8dbf553d11a4a6d433c8863b2fa9eecfd9f1",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.9.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.9.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.9.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.9.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.9.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.9.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.9.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.9.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.9.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.9.bin",
+    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.9.bin",
+    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.9.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.8.9-bitcoinonly.bin",
   "fingerprint": "bde9c5ef485548746150e07a9c5081c25f2bdf127707a41f3c487ca83a6c0667",

--- a/firmware/t2b1/bitcoinonly/t2b1-2.9.0-bitcoinonly.json
+++ b/firmware/t2b1/bitcoinonly/t2b1-2.9.0-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
   "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.9.0.bin",
-    "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.9.0.bin",
-    "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.9.0.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.9.0.bin",
-    "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.9.0.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.9.0.bin"
+    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.9.0.bin",
+    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.9.0.bin",
+    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.9.0.bin",
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.9.0.bin",
+    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.9.0.bin",
+    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.9.0.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.9.0-bitcoinonly.bin",
   "fingerprint": "da044e4187e406351a1a06df903a678fe4a6b325ed9579ea22ce9f6984e42207",

--- a/firmware/t2b1/universal/t2b1-2.6.3-universal.json
+++ b/firmware/t2b1/universal/t2b1-2.6.3-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 6, 1],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.6.3.bin",
-    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.6.3.bin",
-    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.6.3.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.6.3.bin",
-    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.6.3.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.6.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2b1/trezor-t2b1-2.6.3.bin",
   "fingerprint": "1aea81cf4a823951540a041ae52d1950efade73531f7640c85805f8950f11a38",
   "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."

--- a/firmware/t2b1/universal/t2b1-2.6.4-universal.json
+++ b/firmware/t2b1/universal/t2b1-2.6.4-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 6, 1],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.6.4.bin",
-    "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.6.4.bin",
-    "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.6.4.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.6.4.bin",
-    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.6.4.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.6.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2b1/trezor-t2b1-2.6.4.bin",
   "fingerprint": "5ac16cb5002aa607908be376378a7fd1a1bc18f7b05e7a047cb1365840cc93ef",
   "changelog": "* Trezor Safe 3 now supports Solana, expanding the range of cryptocurrencies it can securely manage. [Universal fw only] \n* Ethereum fees are now uniformly presented in Gwei, enhancing clarity and consistency for users. [Universal fw only] \n* Issue with missing address confirmation screens is now fixed. [Universal fw only] \n* Resolved an issue related to the invalid encoding of signatures from the Optiga chip."

--- a/firmware/t2b1/universal/t2b1-2.7.0-universal.json
+++ b/firmware/t2b1/universal/t2b1-2.7.0-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.0.bin",
     "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.0.bin",
     "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.0.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.0.bin",
-    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.7.0.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.7.0.bin"
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.0.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.7.0.bin",
   "fingerprint": "522eb5db073c0f039f7164360668e75a43399d0b4e40edfd06f77f4401cd98aa",

--- a/firmware/t2b1/universal/t2b1-2.7.2-universal.json
+++ b/firmware/t2b1/universal/t2b1-2.7.2-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.2.bin",
     "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.2.bin",
     "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.7.2.bin"
+    "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t2b1/trezor-t2b1-2.7.2.bin",
   "fingerprint": "d072560f34782faf5537aa08a48c4e24671d4c60e9c291a00bfbf12cbc425666",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 1, 0],
   "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.5.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.5.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.5.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.5.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.5.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.5.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.5-bitcoinonly.bin",
   "fingerprint": "9de90d9f8ca12506f3b9a4cbe7616294144d965d67daa3a03bfe6c0b74a44843",
   "changelog": "* Fix UI for Shamir with 33 words"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.6.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.6.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.6.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.6.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.6.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.6.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.6-bitcoinonly.bin",
   "fingerprint": "4e7f0f95d71631159b9e873f36a812c93a10eca1fad5f38c78ae7fbe4c1f6ed4",
   "changelog": "* Small code improvements."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.7.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.7.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.7.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.7.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.7.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.7.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.7-bitcoinonly.bin",
   "fingerprint": "fd92ac173a2cf93cc07ced3287e07800ed10466dc38c0c7240d9b20c689dd1d1",
   "changelog": "* Super Shamir (with Groups)\n* Fix low memory issue"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.8.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.8.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.8.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.8.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.8.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.8.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.8-bitcoinonly.bin",
   "fingerprint": "ec752e9fa99a29979497e093b32bdb2b592783e2b48c87d8f6f0c18c73cd3022",
   "changelog": "* Show XPUBs in GetAddress for multisig\n* Security improvements"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.0-bitcoinonly.bin",
   "fingerprint": "bddc0fd3b52fd32d94b776048f62b3d03dcb6ab90140e482a042a2863093115f",
   "changelog": "* Introduce Wipe code\n* Introduce SD card protection\n* Introduce passphrase cache\n* Security fixes"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.1-bitcoinonly.bin",
   "fingerprint": "41795ec196f74c5d6acecc09047a5eacf1dfca47b0aeaa8442a69568efe20ddb",
   "changelog": "* Refactor Bitcoin signing"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.2-bitcoinonly.bin",
   "fingerprint": "389cb54fb6fc75489b788ad669ce51f41d47a67af54b8745a0dfe48da38a777f",
   "changelog": "* Introduces 'Autolock' feature, which automatically locks the device to enforce the PIN entry after a certain period.\n* Fixes compatibility issues with Casa and GreenAddress.\n* Adds support for multiple change outputs in outgoing transactions.\n* Improves some interface elements."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.3-bitcoinonly.bin",
   "fingerprint": "dda77cd7893a5f413f8fc4b2f44d1d43ed4b26e8ced5e6e578cc6b302c1a2310",
   "changelog": "* Advances the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Introduces a hard limit on transaction fees to prevent accidentally paying extra hefty fees (the limit can be manually disabled).\n* Fixes smaller issues with the user interface, customization, and more."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.4.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.4.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.4.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.4.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.4.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.4-bitcoinonly.bin",
   "fingerprint": "085acbba98163284ef86dea637f9442b924e80fea245f5ebb60d5aab3be2b7b6",
   "changelog": "* Small code improvements."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.5.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.5.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.5.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.5.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.5.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.5.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.5-bitcoinonly.bin",
   "fingerprint": "53e7ee5bfc75cfa6412d8de5461b1ea8d9b7e10970ce7cadae9cbb1e17bbb77d",
   "changelog": "* Replacement transaction signing for replace-by-fee and PayJoin.\n* Support for Output Descriptors export.\n* Paginated display for signing/verifying long messages.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.6.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.6.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.6.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.6.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.6.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.6.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.6-bitcoinonly.bin",
   "fingerprint": "e2cab40bb4c6ae65417b80ad564b905796038a0f5e6d0f50cead257fdd3a9c2d",
   "changelog": "* Add compatibility paths for Unchained Capital"

--- a/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.0-bitcoinonly.bin",
   "fingerprint": "89c91287ab7a9cd3ec246b6822a0d04b7d40401abef706cccafbb7b98bd6a3d7",
   "changelog": "* Locking the device by holding finger on the homescreen.\n* Support PIN of unlimited length.\n* Allow decreasing the output value in RBF transactions.\n* Reduce memory fragmentation.\n* Improve wording when showing multisig XPUBs."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.1-bitcoinonly.bin",
   "fingerprint": "fce4503fcadb68dc72144a562ec0a59e7c8d083e403e01bfc4c584161d79f596",
   "changelog": "* Security and major perfomance improvements.\n* Fix red screen on shutdown."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.2-bitcoinonly.bin",
   "fingerprint": "60fee3c9775d8ccf71099f6f7d277463efd128414cfb9be45656b1a26eeb7301",
   "changelog": "* Memory optimization of BTC signing."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.3-bitcoinonly.bin",
   "fingerprint": "1744efccabd479526392b281b7e0fc7aa2b4ecb454007dff7ca8c1f8171fad90",
   "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.1-bitcoinonly.bin",
   "fingerprint": "db5d7b211532f717a32fe0b1bd3e3df6ad5464079a896a7f7492ab6e9e030bb5",
   "changelog": "* Support Electrum signatures in VerifyMessage.\n* Bitcoin bech32 addresses QR codes have bigger pixels which are easier to scan.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs)."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.2-bitcoinonly.bin",
   "fingerprint": "76aa25f9602cfb03cd3e07a82ac09226344eb355355aec216295e43b675eedf7",
   "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.3-bitcoinonly.bin",
   "fingerprint": "c094c84ba958129885fa725ee6ddb781b580fd2c7851e83aef9054ba4a10526c",
   "changelog": "* Add SLIP-0025 CoinJoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 0],
   "firmware_revision": "88e1f8c7a5c7615723664c64b0a25adc0c409dee",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.0-bitcoinonly.bin",
   "fingerprint": "54f084dab4be1e64dc2cb970a6de87969407e4d6c48d79acdcf5d374ec0f29d6",
   "changelog": " Show source account path in BTC signing. \n* Ability to reboot the device into bootloader mode directly, without needing to unplug the device. \n* Support for Ledger Live legacy derivation path \"m/44'/coin_type'/0'/account\". \n* Redesigned UI. \n* Homescreen now supports full-screen images."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.3-bitcoinonly.bin",
   "fingerprint": "1765518ca4025d4d46362d07128bb38413831511a2aff0dee1b05e6e58ff5317",
   "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* Adjusted buttons for multipage content scrolling, providing a more intuitive and user-friendly experience. \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.4.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.4.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.4.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.4.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.4.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.4-bitcoinonly.bin",
   "fingerprint": "e78da8a00354dd1223da081600f881b71bd297dd565e7a2c0a9880e52575d127",
   "changelog": "* The display of spaced addresses has been refined, offering a more user-friendly and visually optimized experience. \n* Boot-up logo display has been optimized, contributing to a smoother and more visually appealing device startup."

--- a/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.7.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.7.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.7.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.7.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.7.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.7.0.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.0.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.0.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.0.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.0.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.7.0-bitcoinonly.bin",
   "fingerprint": "c94f07150a6f0bb2862d4c31c6059862aab14f0073dea581118eef51a983bc30",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.7.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.7.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.7.2.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.2.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.2.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.2.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.7.2-bitcoinonly.bin",
   "fingerprint": "cba515383705ec6420c54dd1ffdb33ea7ce4bb04bc6d992c2923880daa53d3e1",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 6],
   "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.1.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.1.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.1.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.1.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.1.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.1.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.1.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.8.1-bitcoinonly.bin",
   "fingerprint": "38ab127fcf4263a18a3b07593301fdd2c6a1a96360b62c131adb849b5d18fae3",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.10.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.10.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.10.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.10.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.10.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.10.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.10.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.10.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.10.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.10.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.10.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.10.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin",
   "fingerprint": "c280cfbe83b261ef30c64eb58f55538b3cceee01ba7d8f57d6e8cbf92527066b",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.7.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.7.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.7.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.7.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.7.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.7.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.7.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.7.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.7.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.7.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.7.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.7.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin",
   "fingerprint": "7bdf5de0c00c5d15c06d526a5b0d22cfd8343eb3e7aa01ee3c4ed60dd063bbf1",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.8.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.8.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.8.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.8.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.8.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.8.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.8.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.8.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.8.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.8.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.8.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.8.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.8.8-bitcoinonly.bin",
   "fingerprint": "81928bbb5bc855f46a2ccb210173f9676b69d153a513bfa0101abfc063f7aef5",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.9.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.9.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.9.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.9.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.9.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.9.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.9.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.9.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.9.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.9.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.9.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.9.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.8.9-bitcoinonly.bin",
   "fingerprint": "e5878fa067df9d1256cdcd86f10869930d85e090c39f807c23f8845472e8d995",

--- a/firmware/t2t1/bitcoinonly/t2t1-2.9.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.9.0-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
   "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.9.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.9.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.9.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.9.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.9.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.9.0.bin"
+    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.9.0.bin",
+    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.9.0.bin",
+    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.9.0.bin",
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.9.0.bin",
+    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.9.0.bin",
+    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.9.0.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.9.0-bitcoinonly.bin",
   "fingerprint": "4cbaa64a0c9191745e8452245f235c00b053ccd157085e640c52ed9c27ccda19",

--- a/firmware/t2t1/universal/t2t1-2.0.10-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.10-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 2],
   "firmware_revision": "5c3a5d4577b568d90bfa3528d0243d74848d994f",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.10.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.10.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.10.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.10.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.10.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.10.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.10.bin",
   "fingerprint": "fcaa6ee206c2c121eb2d45d065d66f0879f14be45c244d4acf908be1de22275e",
   "changelog": "* Fix Monero payment ID computation\n* Fix issue with touch screen and flickering\n* Add support for OMNI layer: OMNI/MAID/USDT\n* Add support for new coins: BTX, CPC, GAME, RVN\n* Add support for new Ethereum tokens"

--- a/firmware/t2t1/universal/t2t1-2.0.5-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.5-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 0],
   "firmware_revision": "8852fb54820032f4f287414aa250df981d25445f",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.5.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.5.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.5.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.5.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.5.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.5.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.5.bin",
   "fingerprint": "851172eab96c07bf9efb43771cb0fd14dc0320a68de047132c7bd787a1ad64e9",
   "changelog": "* First public release"

--- a/firmware/t2t1/universal/t2t1-2.0.6-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.6-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 0],
   "firmware_revision": "886888b7750402d9a9e12bd990e75c0a8dc6cc86",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.6.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.6.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.6.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.6.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.6.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.6.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.6.bin",
   "fingerprint": "4eccabf2fd7e121ed0da657c064a65c5694402497e60ea2ac2dcf1e118db9cc6",
   "changelog": "* Fix layout for Ethereum transactions\n* Fix public key generation for SSH and GPG\n* Add special characters to passphrase keyboard"

--- a/firmware/t2t1/universal/t2t1-2.0.7-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.7-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 0],
   "firmware_revision": "5c621800110a791c84865b6b381908e8c2f15283",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.7.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.7.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.7.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.7.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.7.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.7.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.7.bin",
   "fingerprint": "f3a42e640e526fba6574fafa520fc7d97ef9f557d24da24d9a2ea4176a4c4164",
   "changelog": "* Bitcoin Cash cashaddr support\n* Zcash Overwinter hardfork support\n* NEM support\n* Lisk support\n* Show warning on home screen if PIN is not set\n* Support for new coins:\n  - Bitcoin Private, Fujicoin, Vertcoin, Viacoin, Zcoin\n* Support for new Ethereum networks:\n  - EOS Classic, Ethereum Social, Ellaism, Callisto, EtherGem, Wanchain\n* Support for 500+ new Ethereum tokens"

--- a/firmware/t2t1/universal/t2t1-2.0.8-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.8-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 0],
   "firmware_revision": "939a93221941df8d454569a674f6fb082bf1d423",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.8.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.8.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.8.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.8.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.8.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.8.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.8.bin",
   "fingerprint": "642b6215bda981f8eacafee34dbee5cdeee7d47d49f605bbe2828a8d9b79813d",
   "changelog": "* Monero support\n* Cardano support\n* Stellar support\n* Ripple support\n* Tezos support\n* Decred support\n* Groestlcoin support\n* Zencash support\n* Zcash sapling hardfork support\n* Implemented seedless setup"

--- a/firmware/t2t1/universal/t2t1-2.0.9-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.0.9-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 0],
   "firmware_revision": "7c2e9ed5a51dc00dec9d195878c5ad57016b4889",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.9.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.9.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.9.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.9.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.9.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.9.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.0.9.bin",
   "fingerprint": "87be93d6966e7a9eff78dc7b434d1a138ec8d1ee0300882d16f90b606f3a806b",
   "changelog": "* Small Monero and Segwit bugfixes"

--- a/firmware/t2t1/universal/t2t1-2.1.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.0-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 5],
   "bootloader_version": [2, 0, 3],
   "firmware_revision": "3f0e3a334e03f49ff819d14cbbec00194c586c27",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.0.bin",
   "fingerprint": "bb5b0308807b45d41d1e2ab66a468152997ad69a01099789d8a35e464cde999f",
   "changelog": "* Security improvements\n* Upgraded to new storage format\n* Ripple, Stellar, Cardano and NEM fixes\n* New coins: ATS, AXE, FLO, GIN, KMD, NIX,\n  PIVX, REOSC, XPM, XSN, ZCL\n* New ETH tokens"

--- a/firmware/t2t1/universal/t2t1-2.1.1-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.1-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 5],
   "firmware_revision": "7af1d5859458e87efd6957885566aed890a9f781",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.1.bin",
   "fingerprint": "1b3166a878658fcd2ff82c7ac9a2587da544fd105f678cc7b4d41cba5a8d4c01",
   "changelog": "* Hotfix for touchscreen freeze\n* Don't rotate the screen via swipe gesture\n* Set screen rotation via user setting\n* More strict path validations\n* Display non-zero locktime values\n* EOS support\n* Monero UI fixes\n* Speed and memory optimizations"

--- a/firmware/t2t1/universal/t2t1-2.1.4-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.4-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 1, 0],
   "firmware_revision": "6a1a02ca3c595067ed02a78f2d6c36eb58eaa9ed",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.4.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.4.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.4.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.4.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.4.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.4.bin",
   "fingerprint": "820611a92605b1ccc612b9bf8550617aec6962bd2484fcb6ae4792bc498654e4",
   "changelog": "* Shamir Backup with Recovery persistence\n* Touchscreen freeze fix\n* Fix display of non-divisible OMNI amounts"

--- a/firmware/t2t1/universal/t2t1-2.1.5-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.5-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 1, 0],
   "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.5.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.5.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.5.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.5.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.5.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.5.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.5.bin",
   "fingerprint": "40e4bfaf3c5ec77872c1aaaac085aafcc443f60279ca2bb38d29c669233fdf62",
   "changelog": "* Fix for sluggish U2F authentication when using Shamir\n* Fix UI for Shamir with 33 words\n* Fix Wanchain signing"

--- a/firmware/t2t1/universal/t2t1-2.1.6-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.6-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.6.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.6.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.6.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.6.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.6.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.6.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.6.bin",
   "fingerprint": "e2032ad84108a85d4014d477b955b9181a1a56e6f222ef21bb7d47b503a02f0b",
   "changelog": "* Super Shamir (with Groups)\n* FIDO2 support with credential management"

--- a/firmware/t2t1/universal/t2t1-2.1.7-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.7-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.7.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.7.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.7.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.7.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.7.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.7.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.7.bin",
   "fingerprint": "acf1b4c6fec3624a8fc53f9130ff53d690c3fa1c134bd4ca3e58ee7b5a0441d8",
   "changelog": "* Super Shamir (with Groups)\n* FIDO2 support with credential management\n* Fix low memory issue"

--- a/firmware/t2t1/universal/t2t1-2.1.8-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.8-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.8.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.8.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.8.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.8.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.8.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.8.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.1.8.bin",
   "fingerprint": "8a5fa12132651b6e33344fd025d0d90885f5cc1c342427ebcea4f0ae98b50d8c",
   "changelog": "* Support Tezos 005-BABYLON hardfork\n* Show XPUBs in GetAddress for multisig\n* Security improvements"

--- a/firmware/t2t1/universal/t2t1-2.3.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.0-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.0.bin",
   "fingerprint": "212929f63fe1393e2ff57e06537a38cff281e3cfb3a4e17235079e2f08871e6c",
   "changelog": "* Introduce Wipe code\n* Introduce SD card protection\n* Introduce passphrase cache\n* U2F UX improvements\n* Security fixes"

--- a/firmware/t2t1/universal/t2t1-2.3.1-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.1-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.1.bin",
   "fingerprint": "37178a5ec24e34f8a0599aebcadaf206af3ebadef2fc596665d617dd3e05a5db",
   "changelog": "* Refactor Bitcoin signing"

--- a/firmware/t2t1/universal/t2t1-2.3.2-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.2-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.2.bin",
   "fingerprint": "f5ccdca0cbe163ecb93df726da72b69abb93f70d24d295db00b3ca2738216160",
   "changelog": "* Introduces 'Autolock' feature, which automatically locks the device to enforce the PIN entry after a certain period.\n* Updates the Cardano support to enable staking and other Shelley updates.\n* Reintroduces the ability to spend pre-Overwinter (2018) funds on Zcash-like coins.\n* Fixes compatibility issues with Casa and GreenAddress.\n* Adds support for multiple change outputs in outgoing transactions.\n* Improves some interface elements."

--- a/firmware/t2t1/universal/t2t1-2.3.3-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.3-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.3.bin",
   "fingerprint": "46326222f8afcb82e1cd07867bc3bf8836f4e9d0f367e23b58d1e9bc32cd032e",
   "changelog": "* Advances the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Adds support for Verge (XVG).\n* Drops support for Metaverse (ETP), GINcoin (GIN), Pesetacoin (PTC), and Zel (ZEL).\n* Introduces a hard limit on transaction fees to prevent accidentally paying extra hefty fees (the limit can be manually disabled).\n* Resolves the problems with generating the Crown addresses.\n* Re-enables spending altcoins from Bitcoin paths (fixing some compatibility issues with Bitcoin Cash wallets).\n* Fixes smaller issues with the user interface, customization, and more."

--- a/firmware/t2t1/universal/t2t1-2.3.4-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.4-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.4.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.4.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.4.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.4.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.4.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.4.bin",
   "fingerprint": "58b51a6587993965979a744f8fcd5c4761f11ce4bec6b059a5d56bd0987d6658",
   "changelog": "* This firmware only contains the changes needed after the latest Monero update (HF13) by introducing support for the CLSAG transactions."

--- a/firmware/t2t1/universal/t2t1-2.3.5-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.5-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.5.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.5.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.5.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.5.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.5.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.5.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.5.bin",
   "fingerprint": "c0a6cacfed5c7a691314919c22307c29fbe9522071a9a28669769c014762d386",
   "changelog": "* Replacement transaction signing for replace-by-fee and PayJoin.\n* Support for Output Descriptors export.\n* Paginated display for signing/verifying long messages.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."

--- a/firmware/t2t1/universal/t2t1-2.3.6-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.6-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.6.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.6.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.6.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.6.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.6.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.6.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.3.6.bin",
   "fingerprint": "0efa3ba6135caea7693d145d60441eeb46283fe0b8b1fd59a04af33a638ad237",
   "changelog": "* Add compatibility paths for Unchained Capital"

--- a/firmware/t2t1/universal/t2t1-2.4.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.4.0-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.0.bin",
   "fingerprint": "d90265ee6d7d499c7d938b5322f71f27042da8a6fdaed54c224d31b65e868def",
   "changelog": "* Locking the device by holding finger on the homescreen.\n* Support PIN of unlimited length.\n* Allow decreasing the output value in RBF transactions.\n* Reduce memory fragmentation.\n* Update FIDO icons.\n* Improve wording when showing multisig XPUBs."

--- a/firmware/t2t1/universal/t2t1-2.4.1-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.4.1-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.1.bin",
   "fingerprint": "84bc47bb197b3ae7bfb096f03d4a528ccf6c9ef4dfee0aac4022971e4ec91d68",
   "changelog": "* Security and major perfomance improvements.\n* Cardano fixes.\n* Fix red screen on shutdown."

--- a/firmware/t2t1/universal/t2t1-2.4.2-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.4.2-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.2.bin",
   "fingerprint": "54ccf155510b5292bd17ed748409d0d135112e24e62eb74184639460beecb213",
   "changelog": "* Support for Ethereum EIP1559 transactions.\n* Re-enabled Firo support.\n* Memory optimization of BTC signing and CBOR decoding.\n* Support for large Cardano transactions.\n* Remove Lisk."

--- a/firmware/t2t1/universal/t2t1-2.4.3-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.4.3-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.4.3.bin",
   "fingerprint": "a07f69d8d2065006a79c6b5636bd046496dbcb3820b41f1d604d8a4605ca4056",
   "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage.\n* Support for advanced Cardano transactions and different derivations for compatibility.\n* Ethereum support for EIP712 (signing typed data)."

--- a/firmware/t2t1/universal/t2t1-2.5.1-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.5.1-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.1.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.1.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.1.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.1.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.1.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.1.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.1.bin",
   "fingerprint": "782d4934897018cac779eebb0d7c66e21da7789b9cd35e1f99f097bdfd9b7d33",
   "changelog": "* Support Electrum signatures in VerifyMessage.\n* Support Cardano Alonzo-era transactions (Plutus).\n* Bitcoin bech32 addresses QR codes have bigger pixels which are easier to scan.\n* EIP-1559 transaction correctly show final Hold to Confirm screen.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs).\n* Zcash v5 transaction format."

--- a/firmware/t2t1/universal/t2t1-2.5.2-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.5.2-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.2.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.2.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.2.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.2.bin",
   "fingerprint": "659b1b698546fa63f24200e148b6f9a7044df31d11a0a5ec7c044f2dd83f4a27",
   "changelog": "* Add support for Monero HF15 features. \n* Show the fee rate on the signing confirmation screen. \n* Support for Cardano Babbage era transaction items \n* Add \"Show All\"/\"Show Simple\" choice to Cardano transaction signing \n* Show thousands separator when displaying large amounts. \n* Fix Decred transaction weight calculation."

--- a/firmware/t2t1/universal/t2t1-2.5.3-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.5.3-universal.json
@@ -5,14 +5,7 @@
   "min_bootloader_version": [2, 0, 0],
   "min_firmware_version": [2, 0, 8],
   "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.5.3.bin",
   "fingerprint": "4f57dca1abc1a60d82c4fef7c96e86d784fc7a1e5e3da724dd2ae4d14c6350bf",
   "changelog": "* Add SLIP-0025 CoinJoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Add support for Zcash unified addresses. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Support for Cardano CIP-36 governance registration format. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”. \n* Fix sending XMR transaction to an integrated address. \n* Fix XMR primary address display."

--- a/firmware/t2t1/universal/t2t1-2.6.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.6.0-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 0],
   "firmware_revision": "88e1f8c7a5c7615723664c64b0a25adc0c409dee",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.0.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.0.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.0.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.0.bin",
   "fingerprint": "050526db604b9acceef2a5a8561bc99ecbe337909283ebb927b556d8e9b13872",
   "changelog": "* Show source account path in BTC signing. \n* Address confirmation screen added to EIP712 signing flow. \n* Ability to reboot the device into bootloader mode directly, without needing to unplug the device. \n* Support for Ledger Live legacy derivation path \"m/44'/coin_type'/0'/account\". \n* Redesigned UI. \n* Homescreen now supports full-screen images. \n* Force basic attestation in FIDO2 for google.com."

--- a/firmware/t2t1/universal/t2t1-2.6.3-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.6.3-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.3.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.3.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.3.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.3.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.3.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.3.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.3.bin",
   "fingerprint": "9ff0874f2ce3579a7502747578cef65c824097d906e7150b0142f6b9aa395a43",
   "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* Adjusted buttons for multipage content scrolling, providing a more intuitive and user-friendly experience. \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security."

--- a/firmware/t2t1/universal/t2t1-2.6.4-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.6.4-universal.json
@@ -6,14 +6,7 @@
   "min_firmware_version": [2, 0, 8],
   "bootloader_version": [2, 1, 4],
   "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
-  "translations": {
-    "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.4.bin",
-    "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.4.bin",
-    "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.4.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.4.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.4.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.4.bin"
-  },
+  "translations": {},
   "url": "firmware/t2t1/trezor-t2t1-2.6.4.bin",
   "fingerprint": "441faa92156e8ae0b8247f9434c3ec8cf6ffd872f16fc593b22c4460dfd93913",
   "changelog": "* Trezor Model T now supports Solana, expanding the range of cryptocurrencies it can securely manage. [Universal fw only] \n* Ethereum fees are now uniformly presented in Gwei, enhancing clarity and consistency for users. [Universal fw only] \n* The display of spaced addresses has been refined, offering a more user-friendly and visually optimized experience. \n* Boot-up logo display has been optimized, contributing to a smoother and more visually appealing device startup."

--- a/firmware/t2t1/universal/t2t1-2.7.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.7.0-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.0.bin",
     "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.0.bin",
     "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.0.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.0.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.7.0.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.7.0.bin"
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.0.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.7.0.bin",
   "fingerprint": "53a645218792e413ad06c27320b7d1adc944b690ce831301bbf11c30352d3278",

--- a/firmware/t2t1/universal/t2t1-2.7.2-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.7.2-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.2.bin",
     "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.2.bin",
     "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.7.2.bin"
+    "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t2t1/trezor-t2t1-2.7.2.bin",
   "fingerprint": "d64fcf47a8ead6edf0329583e312136d1548d30990c29cfaa2ce7c67197babcc",

--- a/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
+++ b/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 10],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
   "translations": {
-    "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.10.bin",
-    "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.10.bin",
-    "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.10.bin",
-    "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.10.bin",
-    "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.10.bin",
-    "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.10.bin"
+    "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.10.bin",
+    "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.10.bin",
+    "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.10.bin",
+    "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.10.bin",
+    "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.10.bin",
+    "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.10.bin"
   },
   "url": "firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin",
   "fingerprint": "5a0aa661b61d056f72b83bf0d5c7eb4ddc84d6370fb977be794b145e49e8ff3f",

--- a/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
+++ b/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
   "translations": {
-    "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.3.bin",
-    "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.3.bin",
-    "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.3.bin",
-    "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.3.bin",
-    "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.3.bin",
-    "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.3.bin"
+    "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.3.bin",
+    "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.3.bin",
+    "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.3.bin",
+    "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.3.bin",
+    "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.3.bin",
+    "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.3.bin"
   },
   "url": "firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin",
   "fingerprint": "070a61b2a8653e4f9857810b6610d0a15f76ba627c7b6e5654a6de9a1c529049",

--- a/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
+++ b/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
   "translations": {
-    "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.7.bin",
-    "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.7.bin",
-    "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.7.bin",
-    "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.7.bin",
-    "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.7.bin",
-    "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.7.bin"
+    "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.7.bin",
+    "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.7.bin",
+    "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.7.bin",
+    "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.7.bin",
+    "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.7.bin",
+    "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.7.bin"
   },
   "url": "firmware/t3b1/trezor-t3b1-2.8.7-bitcoinonly.bin",
   "fingerprint": "4737a6e12d0ebff19fec3aceb212adff57bbcea7a44f8208caf91cc656382d94",

--- a/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
+++ b/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
   "translations": {
-    "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.9.bin",
-    "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.9.bin",
-    "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.9.bin",
-    "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.9.bin",
-    "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.9.bin",
-    "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.9.bin"
+    "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.9.bin",
+    "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.9.bin",
+    "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.9.bin",
+    "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.9.bin",
+    "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.9.bin",
+    "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.9.bin"
   },
   "url": "firmware/t3b1/trezor-t3b1-2.8.9-bitcoinonly.bin",
   "fingerprint": "d3905f15221f7b2733e5496986ceb1a3b39f390c4439e2d3cc89d5f3b7423278",

--- a/firmware/t3b1/bitcoinonly/t3b1-2.9.0-bitcoinonly.json
+++ b/firmware/t3b1/bitcoinonly/t3b1-2.9.0-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 10],
   "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
   "translations": {
-    "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.9.0.bin",
-    "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.9.0.bin",
-    "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.9.0.bin",
-    "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.9.0.bin",
-    "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.9.0.bin",
-    "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.9.0.bin"
+    "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.9.0.bin",
+    "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.9.0.bin",
+    "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.9.0.bin",
+    "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.9.0.bin",
+    "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.9.0.bin",
+    "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.9.0.bin"
   },
   "url": "firmware/t3b1/trezor-t3b1-2.9.0-bitcoinonly.bin",
   "fingerprint": "ef16d4e2529cbf4dd6a45f9b15177883873819dd886134dc5986cb5b71c5556f",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 6],
   "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.7.2.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.7.2.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.7.2.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.7.2.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.7.2.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.7.2.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.7.2-bitcoinonly.bin",
   "fingerprint": "246cca86b0a8cfcac6b7e6b3fcf55f543a8a9c9fd1f8ff88cd0de00640cb25eb",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 6],
   "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.0.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.0.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.0.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.0.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.0.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.0.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.0.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.0.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.0.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.0.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.0-bitcoinonly.bin",
   "fingerprint": "3dc847cc396fe83f5a324242097a4cf97fc64acf90516efcfcf23b6d3103a992",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
@@ -7,12 +7,10 @@
   "bootloader_version": [2, 1, 6],
   "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.1.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.1.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.1.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.1.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.1.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.1.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.1.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.1.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.1.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.1.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.1-bitcoinonly.bin",
   "fingerprint": "6b17de0c89c9a7876687d6b9c44673f4aca7f8819237a755090848a3829bc36b",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 10],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.10.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.10.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.10.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.10.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.10.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.10.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.10.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.10.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.10.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.10.bin",
+    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.10.bin",
+    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.10.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin",
   "fingerprint": "11d3f68d08f3f95c04dd526826f81eb7918df85928cfcef73beeae3132342bf0",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 8],
   "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.3.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.3.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.3.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.3.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.3.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.3.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.3.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.3.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.3.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.3.bin",
+    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.3.bin",
+    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.3.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin",
   "fingerprint": "9eaf99a9420d2a3b9377102eb06b938f5a1886ecb06cccde7fd3cb7a39e1abd7",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 9],
   "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.7.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.7.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.7.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.7.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.7.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.7.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.7.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.7.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.7.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.7.bin",
+    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.7.bin",
+    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.7.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.7-bitcoinonly.bin",
   "fingerprint": "2f58de2b7c2c29b6a2f14909ad0941e4aa9dd6d3e1416ab66c512a743b5385a9",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 10],
   "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.9.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.9.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.9.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.9.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.9.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.9.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.9.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.9.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.9.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.9.bin",
+    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.9.bin",
+    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.9.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.9-bitcoinonly.bin",
   "fingerprint": "ac995c394f7a7b3ea4cbd9c04977621d6d2fbef30bba856f707f585f34866ac4",

--- a/firmware/t3t1/bitcoinonly/t3t1-2.9.0-bitcoinonly.json
+++ b/firmware/t3t1/bitcoinonly/t3t1-2.9.0-bitcoinonly.json
@@ -7,12 +7,12 @@
   "bootloader_version": [2, 1, 10],
   "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
   "translations": {
-    "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.9.0.bin",
-    "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.9.0.bin",
-    "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.9.0.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.9.0.bin",
-    "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.9.0.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.9.0.bin"
+    "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.9.0.bin",
+    "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.9.0.bin",
+    "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.9.0.bin",
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.9.0.bin",
+    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.9.0.bin",
+    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.9.0.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.9.0-bitcoinonly.bin",
   "fingerprint": "6726de011043c01eafbe153f869725a1544f63e15ca24f5530aecadb8ecfe1be",

--- a/firmware/t3t1/universal/t3t1-2.7.2-universal.json
+++ b/firmware/t3t1/universal/t3t1-2.7.2-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.7.2.bin",
     "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.7.2.bin",
     "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.7.2.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.7.2.bin",
-    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.7.2.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.7.2.bin"
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.7.2.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.7.2.bin",
   "fingerprint": "4daa5fd3c4c92ee0d76855997dde09a7ee25f4165b118c521ab10957c5fc92b0",

--- a/firmware/t3t1/universal/t3t1-2.8.0-universal.json
+++ b/firmware/t3t1/universal/t3t1-2.8.0-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.0.bin",
     "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.0.bin",
     "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.0.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.0.bin",
-    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.0.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.0.bin"
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.0.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.0.bin",
   "fingerprint": "bd199ce0934769aca5c3a91f71fd48e533d88c8cf087b76ac49db415fa08c286",

--- a/firmware/t3t1/universal/t3t1-2.8.1-universal.json
+++ b/firmware/t3t1/universal/t3t1-2.8.1-universal.json
@@ -10,9 +10,7 @@
     "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.1.bin",
     "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.1.bin",
     "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.1.bin",
-    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.1.bin",
-    "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.1.bin",
-    "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.1.bin"
+    "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.1.bin"
   },
   "url": "firmware/t3t1/trezor-t3t1-2.8.1.bin",
   "fingerprint": "6a064df4a928e1264d682a34cc014fc9272f312e0f8a8270ff88d6f1408fe68b",


### PR DESCRIPTION
Correcting 2 mistakes in the new releases JSONs:

1. Not all the releases of a devices that support translations had translations
2. Not all the releases of a devices that support translations had translations for all supported languages
3. There was a typo in bitcoinonly releases JSONs where the device model was not capitalize as it should `firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.10.bin`


I added new check to script `scripts/check-firmware-presence-in-releases-json-separated.sh` that checks that all the releases JSON contain translations binary that exist in the repository.