### PR TITLE
fix(firmware): add missing requried true to JSONs release

### DIFF
--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [1, 9, 0],
   "min_bridge_version": [2, 0, 25],
   "min_bootloader_version": [1, 5, 0],

--- a/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [1, 8, 1],
   "min_bridge_version": [2, 0, 25],
   "min_bootloader_version": [1, 5, 0],

--- a/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [1, 9, 0],
   "min_bridge_version": [2, 0, 25],
   "min_bootloader_version": [1, 5, 0],

--- a/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
+++ b/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [2, 3, 0],
   "min_bridge_version": [2, 0, 7],
   "min_bootloader_version": [2, 0, 0],

--- a/firmware/t2t1/universal/t2t1-2.1.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.1.0-universal.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [2, 1, 0],
   "min_bridge_version": [2, 0, 7],
   "min_bootloader_version": [2, 0, 0],

--- a/firmware/t2t1/universal/t2t1-2.3.0-universal.json
+++ b/firmware/t2t1/universal/t2t1-2.3.0-universal.json
@@ -1,5 +1,5 @@
 {
-  "required": false,
+  "required": true,
   "version": [2, 3, 0],
   "min_bridge_version": [2, 0, 7],
   "min_bootloader_version": [2, 0, 0],


### PR DESCRIPTION
When we changed to the new releases JSONs, we used trezor/data as source of truth, but it was actually not really 100% since there were previous changes that were done to the copy of those releases JSONs in Suite but not here, this PR is trying to align with that 

Issue in Suite https://github.com/trezor/trezor-suite/issues/22028

PR in Suite that is adding the changes https://github.com/trezor/trezor-suite/pull/22135

Link to old commit were those releases.json were still in Suite and they had some `"required": true` different with the ones in trezor/data repository - https://github.com/trezor/trezor-suite/tree/0c16c5f1fc2cdf2c394afa9b0e99a0787d7d9d5d/packages/connect-common/files/firmware