### PR TITLE
feat(fw): add T3W1 2.9.5 with translations

### DIFF
--- a/firmware/t3w1/bitcoinonly/t3w1-2.9.5-bitcoinonly.json
+++ b/firmware/t3w1/bitcoinonly/t3w1-2.9.5-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+  "required": false,
+  "version": [2, 9, 5],
+  "min_bridge_version": [2, 0, 7],
+  "min_bootloader_version": [2, 1, 13],
+  "min_firmware_version": [2, 9, 3],
+  "bootloader_version": [2, 1, 15],
+  "firmware_revision": "aecac16bb1261988d146079e9ab235056cee422e",
+  "translations": {
+    "cs-CZ": "firmware/translations/t3w1/translation-T3W1-cs-CZ-2.9.5.bin",
+    "de-DE": "firmware/translations/t3w1/translation-T3W1-de-DE-2.9.5.bin",
+    "es-ES": "firmware/translations/t3w1/translation-T3W1-es-ES-2.9.5.bin",
+    "fr-FR": "firmware/translations/t3w1/translation-T3W1-fr-FR-2.9.5.bin",
+    "pt-BR": "firmware/translations/t3w1/translation-T3W1-pt-BR-2.9.5.bin"
+  },
+  "url": "firmware/t3w1/trezor-t3w1-2.9.5-bitcoinonly.bin",
+  "fingerprint": "fa31d60e16ceb667b29df3cf862cef73620399aea2afa9d4fd0ba0da2987dd57",
+  "changelog": "* Fixed tamper RSOD not showing."
+}

--- a/firmware/t3w1/releases.json
+++ b/firmware/t3w1/releases.json
@@ -1,6 +1,22 @@
 [
   {
     "required": false,
+    "version": [2, 9, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 13],
+    "min_firmware_version": [2, 9, 3],
+    "bootloader_version": [2, 1, 15],
+    "firmware_revision": "aecac16bb1261988d146079e9ab235056cee422e",
+    "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "pt-BR"],
+    "url": "data/firmware/t3w1/trezor-t3w1-2.9.5.bin",
+    "fingerprint": "be5b323e9d72d20faba66541b16ceb221e752f5061a34dbcd31a2b20c31c8bba",
+    "changelog": "* Fixed tamper RSOD not showing.",
+    "url_bitcoinonly": "data/firmware/t3w1/trezor-t3w1-2.9.5-bitcoinonly.bin",
+    "fingerprint_bitcoinonly": "fa31d60e16ceb667b29df3cf862cef73620399aea2afa9d4fd0ba0da2987dd57",
+    "changelog_bitcoinonly": "* Fixed tamper RSOD not showing."
+  },
+  {
+    "required": false,
     "version": [2, 9, 4],
     "min_bridge_version": [2, 0, 7],
     "min_bootloader_version": [2, 1, 13],

--- a/firmware/t3w1/trezor-t3w1-2.9.5-bitcoinonly.bin
+++ b/firmware/t3w1/trezor-t3w1-2.9.5-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8f1baea5ca254fcf7a147e52f4bf6d835fb6a0cad58d0dbe3fbc615b3aa2b01
+size 1854464

--- a/firmware/t3w1/trezor-t3w1-2.9.5.bin
+++ b/firmware/t3w1/trezor-t3w1-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2878f441ad9a1f7134fbf3f664b1fc99d7748886e8aa393b83bec8aceb43c6d8
+size 2228224

--- a/firmware/t3w1/universal/t3w1-2.9.5-universal.json
+++ b/firmware/t3w1/universal/t3w1-2.9.5-universal.json
@@ -1,0 +1,19 @@
+{
+  "required": false,
+  "version": [2, 9, 5],
+  "min_bridge_version": [2, 0, 7],
+  "min_bootloader_version": [2, 1, 13],
+  "min_firmware_version": [2, 9, 3],
+  "bootloader_version": [2, 1, 15],
+  "firmware_revision": "aecac16bb1261988d146079e9ab235056cee422e",
+  "translations": {
+    "cs-CZ": "firmware/translations/t3w1/translation-T3W1-cs-CZ-2.9.5.bin",
+    "de-DE": "firmware/translations/t3w1/translation-T3W1-de-DE-2.9.5.bin",
+    "es-ES": "firmware/translations/t3w1/translation-T3W1-es-ES-2.9.5.bin",
+    "fr-FR": "firmware/translations/t3w1/translation-T3W1-fr-FR-2.9.5.bin",
+    "pt-BR": "firmware/translations/t3w1/translation-T3W1-pt-BR-2.9.5.bin"
+  },
+  "url": "firmware/t3w1/trezor-t3w1-2.9.5.bin",
+  "fingerprint": "be5b323e9d72d20faba66541b16ceb221e752f5061a34dbcd31a2b20c31c8bba",
+  "changelog": "* Fixed tamper RSOD not showing."
+}

--- a/firmware/translations/t3w1/translation-T3W1-cs-CZ-2.9.5.bin
+++ b/firmware/translations/t3w1/translation-T3W1-cs-CZ-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940126e2e3477213936d5ee529d36dab194c40ddbb5775af8ac00ea1eaaf8f57
+size 75330

--- a/firmware/translations/t3w1/translation-T3W1-de-DE-2.9.5.bin
+++ b/firmware/translations/t3w1/translation-T3W1-de-DE-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69a61b2ad44042669ae63570bec1df8cbeb97bef3873e20d9841128fc4c5eede
+size 39002

--- a/firmware/translations/t3w1/translation-T3W1-es-ES-2.9.5.bin
+++ b/firmware/translations/t3w1/translation-T3W1-es-ES-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a99c0bd43298d8cf82a8909b4c763f0fcb34cda6cc779661909f81b73602c4
+size 51914

--- a/firmware/translations/t3w1/translation-T3W1-fr-FR-2.9.5.bin
+++ b/firmware/translations/t3w1/translation-T3W1-fr-FR-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84bcca1597992454c95aa8a47bca7c9c635c6bd7e8a8801333ab08d79dd57d8d
+size 82832

--- a/firmware/translations/t3w1/translation-T3W1-pt-BR-2.9.5.bin
+++ b/firmware/translations/t3w1/translation-T3W1-pt-BR-2.9.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21a111945c5d6aa43577b22fa1f1a800e8f2c5b02d47ccf8498c4b1e1b7e5c08
+size 59924


### PR DESCRIPTION
Tested locally on a TS7 device.
```
2878f441ad9a1f7134fbf3f664b1fc99d7748886e8aa393b83bec8aceb43c6d8  firmware/t3w1/trezor-t3w1-2.9.5.bin
a8f1baea5ca254fcf7a147e52f4bf6d835fb6a0cad58d0dbe3fbc615b3aa2b01  firmware/t3w1/trezor-t3w1-2.9.5-bitcoinonly.bin
940126e2e3477213936d5ee529d36dab194c40ddbb5775af8ac00ea1eaaf8f57  firmware/translations/t3w1/translation-T3W1-cs-CZ-2.9.5.bin
69a61b2ad44042669ae63570bec1df8cbeb97bef3873e20d9841128fc4c5eede  firmware/translations/t3w1/translation-T3W1-de-DE-2.9.5.bin
24a99c0bd43298d8cf82a8909b4c763f0fcb34cda6cc779661909f81b73602c4  firmware/translations/t3w1/translation-T3W1-es-ES-2.9.5.bin
84bcca1597992454c95aa8a47bca7c9c635c6bd7e8a8801333ab08d79dd57d8d  firmware/translations/t3w1/translation-T3W1-fr-FR-2.9.5.bin
21a111945c5d6aa43577b22fa1f1a800e8f2c5b02d47ccf8498c4b1e1b7e5c08  firmware/translations/t3w1/translation-T3W1-pt-BR-2.9.5.bin
```
