### PR TITLE
chore(firmware): add T1B1 bootloader_hash for versions above 1.8.0

### DIFF
--- a/firmware/1/releases.json
+++ b/firmware/1/releases.json
@@ -11,6 +11,7 @@
         "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",
         "fingerprint_bitcoinonly": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",
         "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
         "notes": "",
         "changelog": "* Clear sign ETH staking transactions on Everstake pool.\n* Use GWei when formatting large ETH amounts.",
         "changelog_bitcoinonly": "*"
@@ -27,6 +28,7 @@
         "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",
         "fingerprint_bitcoinonly": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",
         "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+        "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
         "notes": "",
         "changelog": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code.",
         "changelog_bitcoinonly": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code."
@@ -43,6 +45,7 @@
         "fingerprint": "3c694191f5b66a65cb5bb209adbf113cb40209e644b77162ba996bb7ee8f382b",
         "fingerprint_bitcoinonly": "985fb6a8c87f7547fb810f6c4a8331ebf19c677445810358778eb21eca78a181",
         "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+        "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
         "notes": "https://trezor.io/learn/a/trezor-device-firmware-update-march-2023",
         "changelog": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included.\n* Stellar addresses now shown in full + as a QR code.\n* Ethereum fees now wrapped to the next line when needed.",
         "changelog_bitcoinonly": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included."
@@ -59,6 +62,7 @@
         "fingerprint": "d8b55b68dfe8a8449ce7391e841073ef5d29349638d85b750508bbef5d2de5ec",
         "fingerprint_bitcoinonly": "7e51546f4411ecf44688c681ada72a18495fd08e91f3a0429ab91bc4415b362a",
         "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+        "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-august-2022-a4e3d76214c1",
         "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing.",
         "changelog_bitcoinonly": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing."
@@ -75,6 +79,7 @@
         "fingerprint": "f7c60d0b8c2853afd576867c6562aba5ea52bdc2ce34d0dbb8751f52867c3665",
         "fingerprint_bitcoinonly": "8e17b95b5d302f203de3a8fe27959efd25e3d5140ac9b5e60412f1b3f624995d",
         "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-may-2022-b1af60742291",
         "changelog": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs).\n* Zcash v5 transaction format.",
         "changelog_bitcoinonly": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs)."
@@ -91,6 +96,7 @@
         "fingerprint": "7619fcc73c43ca8a3e6aad3dc3eb6551fed05bb218340efe01a02bb96e9f346b",
         "fingerprint_bitcoinonly": "1d319f643fe2ba5c247b178c7f73b989ab4e43d914a60468566ee7cc5bb9dde0",
         "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-update-january-2022-4a77e4a07a5a",
         "changelog": "* Support for blindly signing EIP-712 data.",
         "changelog_bitcoinonly": "* Small code improvements."
@@ -107,6 +113,7 @@
         "fingerprint": "74dfdfb9addb9d90fedb2c88794b7236af521d21ef0096f9080c25b597c8af86",
         "fingerprint_bitcoinonly": "30d858b022e218f27854f071d568e5a696c937f1316d83b93aadcd178f3b0a38",
         "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-december-2021-d1e74c3ea283",
         "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage.\n* Support for Ethereum EIP-1559 transactions.",
         "changelog_bitcoinonly": "* Support Taproot.\n* Show address confirmation in SignMessage."
@@ -123,6 +130,7 @@
         "fingerprint": "bf0cc936a9afbf0a4ae7b727a2817fb69fba432d7230a0ff7b79b4a73b845197",
         "fingerprint_bitcoinonly": "d1143d2cba9c7dba4d57703d2b7da87859d8668472ffc651177ead6b94e89117",
         "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-september-2021-a490f2ea16c1",
         "changelog": "* Remove Lisk.\n* Re-enabled Firo support.\n* Stricter protobuf field handling in Stellar.",
         "changelog_bitcoinonly": "* Small code improvements"
@@ -139,6 +147,7 @@
         "fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",
         "fingerprint_bitcoinonly": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",
         "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
         "changelog": "* Security improvements.",
         "changelog_bitcoinonly": "* Security improvements."
@@ -155,6 +164,7 @@
         "fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",
         "fingerprint_bitcoinonly": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",
         "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-june-2021-c70aba9f0e3f",
         "changelog": "* Safety checks setting in T1.",
         "changelog_bitcoinonly": "* Safety checks setting in T1."
@@ -171,6 +181,7 @@
         "fingerprint": "595ba3e8e887cba185e03098f9538e18164f72f9fc82445e691abcd03e5cf0a4",
         "fingerprint_bitcoinonly": "20a4068c34ff6dd7d8c510350409376cf7ea744ba668fdcf16da8f1d81fed289",
         "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+        "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
         "notes": "https://blog.trezor.io/trezor-firmware-updates-may-2021-b11f6d52a65b",
         "changelog": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form.",
         "changelog_bitcoinonly": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form."
@@ -187,6 +198,7 @@
         "fingerprint": "867017bd784cc4e9ce6f0875c61ea86f89b19380d54045c34608b85472998000",
         "fingerprint_bitcoinonly": "3f73dfbcfc48f66c8814f6562524d81888230e0acd1c19b52b6e8772c6c67e7f",
         "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-rbf-and-spending-now-live-c2f69c42d7f7",
         "changelog": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations.",
         "changelog_bitcoinonly": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
@@ -203,6 +215,7 @@
         "fingerprint": "2589f456559f813d1149be1022e62f2d48fbe28f4d02de933bd888d91035cace",
         "fingerprint_bitcoinonly": "76f899d60ffd9685713cb420d017565c05c43aadaf0e62b645a50a8db69afef6",
         "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/firmware-updates-for-trezor-model-t-version-2-3-3-and-trezor-model-one-version-1-9-3-c94f7a3b6fea",
         "changelog": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Adds support for Verge (XVG).\n* Drops support for Metaverse (ETP), GINcoin (GIN), Pesetacoin (PTC), and Zel (ZEL).\n* Re-enables spending coins from Bitcoin paths (fixing some compatibility issues with Bitcoin Cash wallets).\n* Fixes smaller issues in the user interface.",
         "changelog_bitcoinonly": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Fixes smaller issues in the user interface."
@@ -219,6 +232,7 @@
         "fingerprint": "45b83acd1330ddfd5567edbae5ff8028df1c48a493f01d47cc5499ee0be9b991",
         "fingerprint_bitcoinonly": "2762c0ff78c96e23d1d348330e0a3cdf45d83c8fc8c2d48853b7cb602ddc19bb",
         "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/firmware-updates-for-trezor-model-t-version-2-3-2-and-trezor-model-one-version-1-9-2-f4f9c0f1ed7c",
         "changelog": "* Reintroduces the ability to spend pre-Overwinter (2018) funds on Zcash-like coins.\n* Adds support for multiple change outputs in outgoing transactions.\n* Adds a security check to prevent potential issues with paths used in altcoin transactions.",
         "changelog_bitcoinonly": "* Adds support for multiple change outputs in outgoing transactions."
@@ -235,6 +249,7 @@
         "fingerprint": "30cde253c46d4fc705f98634a35d06a494cf2a36824622a9c6a573e07f14292d",
         "fingerprint_bitcoinonly": "ee743e3bd1e424ceb45a1d877a5422e7af449706f636c459cdd8bb0d4796cba5",
         "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd",
         "changelog": "* Refactor Bitcoin signing",
         "changelog_bitcoinonly": "* Refactor Bitcoin signing"
@@ -251,6 +266,7 @@
         "fingerprint": "1f40d1e68f9d182888b5b60da5209eff047ec68fcc96a5c9b61b0e55dd07d458",
         "fingerprint_bitcoinonly": "93a670dd20d044bf76cfce6eecd2a85918acdebe616229dbb31250fd03a33870",
         "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-0-and-trezor-model-t-version-2-3-0-46deb141fc09",
         "changelog": "* Introduce Wipe Code\n* Introduce passphrase cache",
         "changelog_bitcoinonly": "* Introduce Wipe Code\n* Introduce passphrase cache"
@@ -267,6 +283,7 @@
         "fingerprint": "496aecfab867504b2283a9f057a0b2fd9d17970a22c81f6ad74232e7b914ce68",
         "fingerprint_bitcoinonly": "13d6089cb935f453eaddbfe193e0ab37924a7aa66f684355a4fe5c660c18247a",
         "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "changelog": "* Small code improvements",
         "changelog_bitcoinonly": "* Small code improvements"
     },
@@ -280,6 +297,7 @@
         "url": "data/firmware/1/trezor-1.8.2.bin",
         "fingerprint": "909742eddcffdc72ca854557962ecad90e97585770f514170abe7a691b0c6eb1",
         "firmware_revision": "3c19e3167d69902305a27f10e43abb5fc7a0254d",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "changelog": "* Security improvements\n* Fix display of non-divisible OMNI amounts"
     },
     {
@@ -292,6 +310,7 @@
         "url": "data/firmware/1/trezor-1.8.1.bin",
         "fingerprint": "019e849c1eb285a03a92bbad6d18a328af3b4dc6999722ebb47677b403a4cd16",
         "firmware_revision": "0a6a5f85729e663fbeae5ce9e5745918ff6f9d5d",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "changelog": "* Fix fault when using the device with no PIN* Fix OMNI transactions parsing"
     },
     {
@@ -305,6 +324,7 @@
         "tags": ["security"],
         "fingerprint": "d65f0c07a6a9c53d8b5287798eb53154b33f9e87cd38a3701970e3d0a750a659",
         "firmware_revision": "964a622bb512aa85cfcc3e451fc70729cc15bb4f",
+        "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
         "notes": "https://blog.trezor.io/firmware-updates-for-trezor-one-firmware-1-8-0-and-trezor-model-t-firmware-2-1-0-b9df91e048df",
         "changelog": "* Security improvements\n* Upgraded to new storage format\n* Stellar and NEM fixes\n* New coins: ATS, KMD, XPM, XSN, ZCL\n* New ETH tokens"
     },

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.0-bitcoinonly.bin",
   "fingerprint": "20a4068c34ff6dd7d8c510350409376cf7ea744ba668fdcf16da8f1d81fed289",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.1-bitcoinonly.bin",
   "fingerprint": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.2-bitcoinonly.bin",
   "fingerprint": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.3-bitcoinonly.bin",
   "fingerprint": "d1143d2cba9c7dba4d57703d2b7da87859d8668472ffc651177ead6b94e89117",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.4-bitcoinonly.bin",
   "fingerprint": "30d858b022e218f27854f071d568e5a696c937f1316d83b93aadcd178f3b0a38",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.5-bitcoinonly.bin",
   "fingerprint": "1d319f643fe2ba5c247b178c7f73b989ab4e43d914a60468566ee7cc5bb9dde0",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.11.1-bitcoinonly.bin",
   "fingerprint": "8e17b95b5d302f203de3a8fe27959efd25e3d5140ac9b5e60412f1b3f624995d",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 11, 0],
   "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+  "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.11.2-bitcoinonly.bin",
   "fingerprint": "7e51546f4411ecf44688c681ada72a18495fd08e91f3a0429ab91bc4415b362a",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.12.1-bitcoinonly.bin",
   "fingerprint": "985fb6a8c87f7547fb810f6c4a8331ebf19c677445810358778eb21eca78a181",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin",
   "fingerprint": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.13.1-bitcoinonly.bin",
   "fingerprint": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.14.0-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "de4b70e2e89a64f3894dba2124f6ec56e5cbd088",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.14.0-bitcoinonly.bin",
   "fingerprint": "0120fdb06e77b27f99e0466dffcde8f1441a00289249e8b628dee9c0f49e88a6",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.14.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.14.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "725c0c01879329900f08fc453d8fd0fcb4d86090",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "url": "firmware/t1b1/trezor-t1b1-1.14.1-bitcoinonly.bin",
   "fingerprint": "39b22b379192506988b72fc430f57a00da1fcaecf3a3c8526909c461951cea30",
   "changelog": "* Enforce advanced recovery for mnemonics shorter than 24 words.",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.8.3-bitcoinonly.bin",
   "fingerprint": "13d6089cb935f453eaddbfe193e0ab37924a7aa66f684355a4fe5c660c18247a",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.0-bitcoinonly.bin",
   "fingerprint": "93a670dd20d044bf76cfce6eecd2a85918acdebe616229dbb31250fd03a33870",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.1-bitcoinonly.bin",
   "fingerprint": "ee743e3bd1e424ceb45a1d877a5422e7af449706f636c459cdd8bb0d4796cba5",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.2-bitcoinonly.bin",
   "fingerprint": "2762c0ff78c96e23d1d348330e0a3cdf45d83c8fc8c2d48853b7cb602ddc19bb",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.3-bitcoinonly.bin",
   "fingerprint": "76f899d60ffd9685713cb420d017565c05c43aadaf0e62b645a50a8db69afef6",

--- a/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
+++ b/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.4-bitcoinonly.bin",
   "fingerprint": "3f73dfbcfc48f66c8814f6562524d81888230e0acd1c19b52b6e8772c6c67e7f",

--- a/firmware/t1b1/releases.json
+++ b/firmware/t1b1/releases.json
@@ -7,6 +7,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "725c0c01879329900f08fc453d8fd0fcb4d86090",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "translations": [],
     "url": "data/firmware/t1b1/trezor-t1b1-1.14.1.bin",
     "fingerprint": "9d0b9070d391d6b71518d2a8143599083ff1afcd3c5fa4136ace46042d7f61e4",
@@ -23,6 +24,7 @@
     "min_firmware_version": [1, 12, 0],
     "bootloader_version": [1, 12, 1],
     "firmware_revision": "de4b70e2e89a64f3894dba2124f6ec56e5cbd088",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "url": "data/firmware/t1b1/trezor-t1b1-1.14.0.bin",
     "fingerprint": "7b33c7d21aff9e2ca70e6667955380436b1e77d1886c15783d9c40031d1b44cb",
     "changelog": "* Send BIP-380 descriptor in GetPublicKey response.\n* Deprecate ETH Holesky testnet and use Hoodi testnet instead.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks. This enables access to networks like Hyperliquid that use conflicting chain IDs and cannot obtain official SLIP-44 registration.\n* Fix cancellation handling during `GetPublicKey`.\n* Use network symbol instead of EVM network shortcut.\n* Make sure EVM symbol is visible.\n* Increase access list capacity of Ethereum EIP1559 transactions from 8 to 12.\n* Fixed side-channel vulnerability in BIP-39 mnemonic processing.",
@@ -42,6 +44,7 @@
     "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",
     "fingerprint_bitcoinonly": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",
     "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "notes": "",
     "changelog": "* Clear sign ETH staking transactions on Everstake pool.\n* Use GWei when formatting large ETH amounts.",
     "changelog_bitcoinonly": "*"
@@ -58,6 +61,7 @@
     "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",
     "fingerprint_bitcoinonly": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",
     "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "notes": "",
     "changelog": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code.",
     "changelog_bitcoinonly": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code."
@@ -74,6 +78,7 @@
     "fingerprint": "3c694191f5b66a65cb5bb209adbf113cb40209e644b77162ba996bb7ee8f382b",
     "fingerprint_bitcoinonly": "985fb6a8c87f7547fb810f6c4a8331ebf19c677445810358778eb21eca78a181",
     "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+    "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
     "notes": "https://trezor.io/learn/a/trezor-device-firmware-update-march-2023",
     "changelog": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included.\n* Stellar addresses now shown in full + as a QR code.\n* Ethereum fees now wrapped to the next line when needed.",
     "changelog_bitcoinonly": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included."
@@ -90,6 +95,7 @@
     "fingerprint": "d8b55b68dfe8a8449ce7391e841073ef5d29349638d85b750508bbef5d2de5ec",
     "fingerprint_bitcoinonly": "7e51546f4411ecf44688c681ada72a18495fd08e91f3a0429ab91bc4415b362a",
     "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-august-2022-a4e3d76214c1",
     "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing.",
     "changelog_bitcoinonly": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing."
@@ -106,6 +112,7 @@
     "fingerprint": "f7c60d0b8c2853afd576867c6562aba5ea52bdc2ce34d0dbb8751f52867c3665",
     "fingerprint_bitcoinonly": "8e17b95b5d302f203de3a8fe27959efd25e3d5140ac9b5e60412f1b3f624995d",
     "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-may-2022-b1af60742291",
     "changelog": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs).\n* Zcash v5 transaction format.",
     "changelog_bitcoinonly": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs)."
@@ -122,6 +129,7 @@
     "fingerprint": "7619fcc73c43ca8a3e6aad3dc3eb6551fed05bb218340efe01a02bb96e9f346b",
     "fingerprint_bitcoinonly": "1d319f643fe2ba5c247b178c7f73b989ab4e43d914a60468566ee7cc5bb9dde0",
     "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-update-january-2022-4a77e4a07a5a",
     "changelog": "* Support for blindly signing EIP-712 data.",
     "changelog_bitcoinonly": "* Small code improvements."
@@ -138,6 +146,7 @@
     "fingerprint": "74dfdfb9addb9d90fedb2c88794b7236af521d21ef0096f9080c25b597c8af86",
     "fingerprint_bitcoinonly": "30d858b022e218f27854f071d568e5a696c937f1316d83b93aadcd178f3b0a38",
     "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-december-2021-d1e74c3ea283",
     "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage.\n* Support for Ethereum EIP-1559 transactions.",
     "changelog_bitcoinonly": "* Support Taproot.\n* Show address confirmation in SignMessage."
@@ -154,6 +163,7 @@
     "fingerprint": "bf0cc936a9afbf0a4ae7b727a2817fb69fba432d7230a0ff7b79b4a73b845197",
     "fingerprint_bitcoinonly": "d1143d2cba9c7dba4d57703d2b7da87859d8668472ffc651177ead6b94e89117",
     "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-september-2021-a490f2ea16c1",
     "changelog": "* Remove Lisk.\n* Re-enabled Firo support.\n* Stricter protobuf field handling in Stellar.",
     "changelog_bitcoinonly": "* Small code improvements"
@@ -170,6 +180,7 @@
     "fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",
     "fingerprint_bitcoinonly": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",
     "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
     "changelog": "* Security improvements.",
     "changelog_bitcoinonly": "* Security improvements."
@@ -186,6 +197,7 @@
     "fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",
     "fingerprint_bitcoinonly": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",
     "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-june-2021-c70aba9f0e3f",
     "changelog": "* Safety checks setting in T1.",
     "changelog_bitcoinonly": "* Safety checks setting in T1."
@@ -202,6 +214,7 @@
     "fingerprint": "595ba3e8e887cba185e03098f9538e18164f72f9fc82445e691abcd03e5cf0a4",
     "fingerprint_bitcoinonly": "20a4068c34ff6dd7d8c510350409376cf7ea744ba668fdcf16da8f1d81fed289",
     "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+    "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
     "notes": "https://blog.trezor.io/trezor-firmware-updates-may-2021-b11f6d52a65b",
     "changelog": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form.",
     "changelog_bitcoinonly": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form."
@@ -218,6 +231,7 @@
     "fingerprint": "867017bd784cc4e9ce6f0875c61ea86f89b19380d54045c34608b85472998000",
     "fingerprint_bitcoinonly": "3f73dfbcfc48f66c8814f6562524d81888230e0acd1c19b52b6e8772c6c67e7f",
     "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/trezor-suite-and-firmware-updates-rbf-and-spending-now-live-c2f69c42d7f7",
     "changelog": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations.",
     "changelog_bitcoinonly": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
@@ -234,6 +248,7 @@
     "fingerprint": "2589f456559f813d1149be1022e62f2d48fbe28f4d02de933bd888d91035cace",
     "fingerprint_bitcoinonly": "76f899d60ffd9685713cb420d017565c05c43aadaf0e62b645a50a8db69afef6",
     "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/firmware-updates-for-trezor-model-t-version-2-3-3-and-trezor-model-one-version-1-9-3-c94f7a3b6fea",
     "changelog": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Adds support for Verge (XVG).\n* Drops support for Metaverse (ETP), GINcoin (GIN), Pesetacoin (PTC), and Zel (ZEL).\n* Re-enables spending coins from Bitcoin paths (fixing some compatibility issues with Bitcoin Cash wallets).\n* Fixes smaller issues in the user interface.",
     "changelog_bitcoinonly": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Fixes smaller issues in the user interface."
@@ -250,6 +265,7 @@
     "fingerprint": "45b83acd1330ddfd5567edbae5ff8028df1c48a493f01d47cc5499ee0be9b991",
     "fingerprint_bitcoinonly": "2762c0ff78c96e23d1d348330e0a3cdf45d83c8fc8c2d48853b7cb602ddc19bb",
     "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/firmware-updates-for-trezor-model-t-version-2-3-2-and-trezor-model-one-version-1-9-2-f4f9c0f1ed7c",
     "changelog": "* Reintroduces the ability to spend pre-Overwinter (2018) funds on Zcash-like coins.\n* Adds support for multiple change outputs in outgoing transactions.\n* Adds a security check to prevent potential issues with paths used in altcoin transactions.",
     "changelog_bitcoinonly": "* Adds support for multiple change outputs in outgoing transactions."
@@ -266,6 +282,7 @@
     "fingerprint": "30cde253c46d4fc705f98634a35d06a494cf2a36824622a9c6a573e07f14292d",
     "fingerprint_bitcoinonly": "ee743e3bd1e424ceb45a1d877a5422e7af449706f636c459cdd8bb0d4796cba5",
     "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd",
     "changelog": "* Refactor Bitcoin signing",
     "changelog_bitcoinonly": "* Refactor Bitcoin signing"
@@ -282,6 +299,7 @@
     "fingerprint": "1f40d1e68f9d182888b5b60da5209eff047ec68fcc96a5c9b61b0e55dd07d458",
     "fingerprint_bitcoinonly": "93a670dd20d044bf76cfce6eecd2a85918acdebe616229dbb31250fd03a33870",
     "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-0-and-trezor-model-t-version-2-3-0-46deb141fc09",
     "changelog": "* Introduce Wipe Code\n* Introduce passphrase cache",
     "changelog_bitcoinonly": "* Introduce Wipe Code\n* Introduce passphrase cache"
@@ -298,6 +316,7 @@
     "fingerprint": "496aecfab867504b2283a9f057a0b2fd9d17970a22c81f6ad74232e7b914ce68",
     "fingerprint_bitcoinonly": "13d6089cb935f453eaddbfe193e0ab37924a7aa66f684355a4fe5c660c18247a",
     "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "changelog": "* Small code improvements",
     "changelog_bitcoinonly": "* Small code improvements"
   },
@@ -311,6 +330,7 @@
     "url": "data/firmware/t1b1/trezor-t1b1-1.8.2.bin",
     "fingerprint": "909742eddcffdc72ca854557962ecad90e97585770f514170abe7a691b0c6eb1",
     "firmware_revision": "3c19e3167d69902305a27f10e43abb5fc7a0254d",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "changelog": "* Security improvements\n* Fix display of non-divisible OMNI amounts"
   },
   {
@@ -323,6 +343,7 @@
     "url": "data/firmware/t1b1/trezor-t1b1-1.8.1.bin",
     "fingerprint": "019e849c1eb285a03a92bbad6d18a328af3b4dc6999722ebb47677b403a4cd16",
     "firmware_revision": "0a6a5f85729e663fbeae5ce9e5745918ff6f9d5d",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "changelog": "* Fix fault when using the device with no PIN* Fix OMNI transactions parsing"
   },
   {
@@ -336,6 +357,7 @@
     "tags": ["security"],
     "fingerprint": "d65f0c07a6a9c53d8b5287798eb53154b33f9e87cd38a3701970e3d0a750a659",
     "firmware_revision": "964a622bb512aa85cfcc3e451fc70729cc15bb4f",
+    "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
     "notes": "https://blog.trezor.io/firmware-updates-for-trezor-one-firmware-1-8-0-and-trezor-model-t-firmware-2-1-0-b9df91e048df",
     "changelog": "* Security improvements\n* Upgraded to new storage format\n* Stellar and NEM fixes\n* New coins: ATS, KMD, XPM, XSN, ZCL\n* New ETH tokens"
   },

--- a/firmware/t1b1/universal/t1b1-1.10.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.0-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.0.bin",
   "fingerprint": "595ba3e8e887cba185e03098f9538e18164f72f9fc82445e691abcd03e5cf0a4",

--- a/firmware/t1b1/universal/t1b1-1.10.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.1.bin",
   "fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",

--- a/firmware/t1b1/universal/t1b1-1.10.2-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.2-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.2.bin",
   "fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",

--- a/firmware/t1b1/universal/t1b1-1.10.3-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.3-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.3.bin",
   "fingerprint": "bf0cc936a9afbf0a4ae7b727a2817fb69fba432d7230a0ff7b79b4a73b845197",

--- a/firmware/t1b1/universal/t1b1-1.10.4-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.4-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.4.bin",
   "fingerprint": "74dfdfb9addb9d90fedb2c88794b7236af521d21ef0096f9080c25b597c8af86",

--- a/firmware/t1b1/universal/t1b1-1.10.5-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.10.5-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.10.5.bin",
   "fingerprint": "7619fcc73c43ca8a3e6aad3dc3eb6551fed05bb218340efe01a02bb96e9f346b",

--- a/firmware/t1b1/universal/t1b1-1.11.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.11.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 10, 0],
   "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+  "bootloader_hash": "7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.11.1.bin",
   "fingerprint": "f7c60d0b8c2853afd576867c6562aba5ea52bdc2ce34d0dbb8751f52867c3665",

--- a/firmware/t1b1/universal/t1b1-1.11.2-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.11.2-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 11, 0],
   "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+  "bootloader_hash": "fa12a44fa05fd1d20539358b54f301cee4c3219c9f1bb3a5772ffd609af9e8e2",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.11.2.bin",
   "fingerprint": "d8b55b68dfe8a8449ce7391e841073ef5d29349638d85b750508bbef5d2de5ec",

--- a/firmware/t1b1/universal/t1b1-1.12.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.12.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.12.1.bin",
   "fingerprint": "3c694191f5b66a65cb5bb209adbf113cb40209e644b77162ba996bb7ee8f382b",

--- a/firmware/t1b1/universal/t1b1-1.13.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.13.0-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.13.0.bin",
   "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",

--- a/firmware/t1b1/universal/t1b1-1.13.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.13.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.13.1.bin",
   "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",

--- a/firmware/t1b1/universal/t1b1-1.14.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.14.0-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "de4b70e2e89a64f3894dba2124f6ec56e5cbd088",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.14.0.bin",
   "fingerprint": "7b33c7d21aff9e2ca70e6667955380436b1e77d1886c15783d9c40031d1b44cb",

--- a/firmware/t1b1/universal/t1b1-1.14.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.14.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 12, 0],
   "bootloader_version": [1, 12, 1],
   "firmware_revision": "725c0c01879329900f08fc453d8fd0fcb4d86090",
+  "bootloader_hash": "94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0",
   "url": "firmware/t1b1/trezor-t1b1-1.14.1.bin",
   "fingerprint": "9d0b9070d391d6b71518d2a8143599083ff1afcd3c5fa4136ace46042d7f61e4",
   "changelog": "* Enforce advanced recovery for mnemonics shorter than 24 words.\n* Warn if Ethereum data is too long.\n* Allow using Ethereum mainnet addresses on all non-Ethereum networks. This enables access to networks like Hyperliquid that use conflicting chain IDs and cannot obtain official SLIP-44 registration.\n* Allow ETH staking operations regardless of source.",

--- a/firmware/t1b1/universal/t1b1-1.8.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.8.0-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "964a622bb512aa85cfcc3e451fc70729cc15bb4f",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.8.0.bin",
   "fingerprint": "d65f0c07a6a9c53d8b5287798eb53154b33f9e87cd38a3701970e3d0a750a659",

--- a/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "0a6a5f85729e663fbeae5ce9e5745918ff6f9d5d",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.8.1.bin",
   "fingerprint": "019e849c1eb285a03a92bbad6d18a328af3b4dc6999722ebb47677b403a4cd16",

--- a/firmware/t1b1/universal/t1b1-1.8.2-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.8.2-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "3c19e3167d69902305a27f10e43abb5fc7a0254d",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.8.2.bin",
   "fingerprint": "909742eddcffdc72ca854557962ecad90e97585770f514170abe7a691b0c6eb1",

--- a/firmware/t1b1/universal/t1b1-1.8.3-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.8.3-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.8.3.bin",
   "fingerprint": "496aecfab867504b2283a9f057a0b2fd9d17970a22c81f6ad74232e7b914ce68",

--- a/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.0.bin",
   "fingerprint": "1f40d1e68f9d182888b5b60da5209eff047ec68fcc96a5c9b61b0e55dd07d458",

--- a/firmware/t1b1/universal/t1b1-1.9.1-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.1-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.1.bin",
   "fingerprint": "30cde253c46d4fc705f98634a35d06a494cf2a36824622a9c6a573e07f14292d",

--- a/firmware/t1b1/universal/t1b1-1.9.2-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.2-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.2.bin",
   "fingerprint": "45b83acd1330ddfd5567edbae5ff8028df1c48a493f01d47cc5499ee0be9b991",

--- a/firmware/t1b1/universal/t1b1-1.9.3-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.3-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.3.bin",
   "fingerprint": "2589f456559f813d1149be1022e62f2d48fbe28f4d02de933bd888d91035cace",

--- a/firmware/t1b1/universal/t1b1-1.9.4-universal.json
+++ b/firmware/t1b1/universal/t1b1-1.9.4-universal.json
@@ -6,6 +6,7 @@
   "min_firmware_version": [1, 6, 2],
   "bootloader_version": [1, 8, 0],
   "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+  "bootloader_hash": "f7fa165be6d780f3e1af00abc07df8b3076bcdad72d70da22a63d8896b6391d8",
   "translations": {},
   "url": "firmware/t1b1/trezor-t1b1-1.9.4.bin",
   "fingerprint": "867017bd784cc4e9ce6f0875c61ea86f89b19380d54045c34608b85472998000",

--- a/scripts/copy-firmware-jsons.py
+++ b/scripts/copy-firmware-jsons.py
@@ -136,6 +136,11 @@ def main(version: str, release_repo: Path):
 
     for model_src in sorted(signed.glob("t?[btw]?")):
         model_name = model_src.name.lower()
+        if model_name == "t1b1":
+            click.secho(
+                "Warning: for T1B1 you should manually backfill the bootloader_hash from trezor-firmware/legacy/firmware/bl_check.txt",
+                fg="yellow",
+            )
 
         # copy signed binaries while matching naming convention
         click.secho(f"\n{model_name} binaries", bold=True)


### PR DESCRIPTION
As part of https://github.com/trezor/trezor-suite-private/issues/209,
backfill optional property `bootloader_hash` to T1B1 with FW versions >=1.9.0
(those are supported by Suite/Connect, it's not worth it to backfill it for lower versions).

Sources:
https://github.com/trezor/trezor-firmware/blob/main/legacy/firmware/bl_check.c#L112-L237
https://github.com/trezor/trezor-firmware/blob/main/legacy/firmware/bl_check.txt

I double checked, but please check it yourself.