### PR TITLE
Chore(scripts): expand check-all-firmware-revisions.sh on T3W1  @Lemonexe

### DIFF
--- a/scripts/check-all-firmware-revisions.sh
+++ b/scripts/check-all-firmware-revisions.sh
@@ -17,8 +17,7 @@ IS_LEGACY="false"
 
 for dir in */ ; do
     DEVICE=${dir%/}
-    # TODO: we excude t3w1 until we have releases on it.
-    if [[ $EXCLUDED_DIR == "$DEVICE" || $DEVICE == "t3w1" ]]; then continue; fi
+    if [[ $EXCLUDED_DIR == "$DEVICE" ]]; then continue; fi
         is_legacy_for_device="$IS_LEGACY"
     if [[ "$DEVICE" == "1" || "$DEVICE" == "2" ]]; then
         is_legacy_for_device="true"

--- a/scripts/check-all-firmware-revisions.sh
+++ b/scripts/check-all-firmware-revisions.sh
@@ -13,18 +13,15 @@ cd "$PARENT_PATH/../firmware" || exit
 
 EXCLUDED_DIR="translations"
 
-IS_LEGACY="false"
-
 for dir in */ ; do
     DEVICE=${dir%/}
+    if [[ ! -d "$dir" ]]; then continue; fi
     if [[ $EXCLUDED_DIR == "$DEVICE" ]]; then continue; fi
-        is_legacy_for_device="$IS_LEGACY"
+        is_legacy_only="false"
     if [[ "$DEVICE" == "1" || "$DEVICE" == "2" ]]; then
-        is_legacy_for_device="true"
+        is_legacy_only="true"
     fi
-    if [ -d "$dir" ]; then
-        if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DEVICE" "$is_legacy_for_device" ; then
-            exit 1
-        fi;
-    fi
+    if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DEVICE" "$is_legacy_only" ; then
+        exit 1
+    fi;
 done


### PR DESCRIPTION
Enable `check-all-firmware-revisions.sh` on T3W1, which [was done in Trezor Suite](https://github.com/trezor/trezor-suite/commit/acafacea41f8ceff48f07e1f7a2f0d900db21f74) but forgotten here.

Also, slightly rewrite to make it better readable (IMO).

I ran the script :heavy_check_mark: , and I shellcheckd it :heavy_check_mark: 